### PR TITLE
Build and release executable with GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,60 @@
+#Template from: https://github.com/ThreeDeeJay/GitHub-Actions-build-templates/blob/main/Windows-MSBuild.yml
+name: Build
+
+env:
+  Branch: ${{github.ref_name}}
+  Configuration: Release
+  Artifacts: Release/${{github.event.repository.name}}.exe
+  Solution: ${{github.event.repository.name}}.sln
+  
+on:
+  push:
+    Branches: $Branch
+  pull_request:
+    Branches: $Branch
+  workflow_dispatch:
+
+jobs:
+  Windows:
+    runs-on: windows-2019
+    steps:
+
+    - name: Clone repo and submodules
+      run: git clone --recurse-submodules https://github.com/${{github.repository}}.git . --branch ${{env.Branch}}
+
+    - name: Get current date, commit hash and count
+      run: |
+        echo "CommitDate=$(git show -s --date=format:'%Y-%m-%d' --format=%cd)" >> $env:GITHUB_ENV
+        echo "CommitHashShort=$(git rev-parse --short=7 HEAD)" >> $env:GITHUB_ENV
+        echo "CommitCount=$(git rev-list --count HEAD)" >> $env:GITHUB_ENV
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Restore NuGet packages
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: nuget restore ${{env.Solution}}
+
+    - name: Build
+      run: msbuild /m ${{env.Solution}} /p:Configuration="${{env.Configuration}}"
+
+    - name: Upload Installer Artifact to GitHub
+      uses: actions/upload-artifact@v4
+      with:
+        name: "${{github.event.repository.name}}_r${{env.CommitCount}}@${{env.CommitHashShort}}"
+        path: "${{github.workspace}}/${{env.Artifacts}}"
+
+    - name: Compress artifacts
+      uses: vimtor/action-zip@v1.1
+      with:
+        files: '${{env.Artifacts}}'
+        dest: "build/${{github.event.repository.name}}_r${{env.CommitCount}}@${{env.CommitHashShort}}.zip"
+
+    - name: GitHub pre-release
+      uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{secrets.GITHUB_TOKEN}}"
+        automatic_release_tag: "latest"
+        prerelease: true
+        title: "[${{env.CommitDate}}] ${{github.event.repository.name}} r${{env.CommitCount}}@${{env.CommitHashShort}}"
+        files: "build/${{github.event.repository.name}}_r${{env.CommitCount}}@${{env.CommitHashShort}}.zip"


### PR DESCRIPTION
Builds and uploads SimFFB.exe to:
- Workflow artifacts (keeps older builds but expires in a couple months): https://github.com/ThreeDeeJay/simFFB/actions/runs/12665920727
- (Pre-)releases (new commits overwrite `latest` tag release, never expires): https://github.com/ThreeDeeJay/simFFB/releases/tag/latest
Currently using Release configuration but we could also set it to compile a Debug build in case it's useful.
This can be useful for anyone modifying the tool and test/share executables easily.
Note that it doesn't seem compatible (freezes) with an old `opt.dat` so it might need to be reconfigured.